### PR TITLE
Implementar CRUD de marcas (backend + panel admin)

### DIFF
--- a/BackEnd/maven-basic-project/src/main/java/com/mycompany/app/MarcaController.java
+++ b/BackEnd/maven-basic-project/src/main/java/com/mycompany/app/MarcaController.java
@@ -4,9 +4,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/marcas")
@@ -42,5 +48,57 @@ public class MarcaController {
         // Requiere: List<Marca> findByCountry(String country); en MarcaRepository
         List<Marca> marcas = marcaRepository.findByCountry(country);
         return new ResponseEntity<>(marcas, HttpStatus.OK);
+    }
+
+    // POST - Crear marca
+    @PostMapping
+    public ResponseEntity<?> crearMarca(@RequestBody Marca marca) {
+        Optional<Marca> marcaExistente = marcaRepository.findByName(marca.getName());
+
+        if (marcaExistente.isPresent()) {
+            return new ResponseEntity<>("Ya existe una marca con ese nombre", HttpStatus.CONFLICT);
+        }
+
+        Marca nuevaMarca = marcaRepository.save(marca);
+        return new ResponseEntity<>(nuevaMarca, HttpStatus.CREATED);
+    }
+
+    // PUT - Actualizar marca por ID
+    @PutMapping("/{id}")
+    public ResponseEntity<?> actualizarMarca(@PathVariable Long id, @RequestBody Marca marcaActualizada) {
+        Marca marcaExistente = marcaRepository.findById(id).orElse(null);
+
+        if (marcaExistente == null) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        // Validar nombre duplicado solo si el nombre cambia
+        if (marcaActualizada.getName() != null
+                && !marcaActualizada.getName().equals(marcaExistente.getName())) {
+
+            Optional<Marca> marcaConEseNombre = marcaRepository.findByName(marcaActualizada.getName());
+            if (marcaConEseNombre.isPresent()) {
+                return new ResponseEntity<>("Ya existe una marca con ese nombre", HttpStatus.CONFLICT);
+            }
+        }
+
+        marcaExistente.setName(marcaActualizada.getName());
+        marcaExistente.setCountry(marcaActualizada.getCountry());
+
+        Marca marcaGuardada = marcaRepository.save(marcaExistente);
+        return new ResponseEntity<>(marcaGuardada, HttpStatus.OK);
+    }
+
+    // DELETE - Eliminar marca por ID
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminarMarca(@PathVariable Long id) {
+        Marca marcaExistente = marcaRepository.findById(id).orElse(null);
+
+        if (marcaExistente == null) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        marcaRepository.deleteById(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/BackEnd/maven-basic-project/src/main/java/com/mycompany/app/MarcaRepository.java
+++ b/BackEnd/maven-basic-project/src/main/java/com/mycompany/app/MarcaRepository.java
@@ -4,10 +4,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MarcaRepository extends JpaRepository<Marca, Long> {
     // Consulta SQL se crea automáticamente:
     // SELECT * FROM marca WHERE country = ?
     List<Marca> findByCountry(String country);
+
+    // Para validar que no se repita el nombre de marca
+    Optional<Marca> findByName(String name);
 }

--- a/BackEnd/maven-basic-project/src/test/java/com/mycompany/app/MarcaControllerTest.java
+++ b/BackEnd/maven-basic-project/src/test/java/com/mycompany/app/MarcaControllerTest.java
@@ -109,4 +109,84 @@ public class MarcaControllerTest {
         assertTrue(respuesta.getBody().isEmpty());
         verify(marcaRepository, times(1)).findByCountry("Italia");
     }
+
+    @Test
+    void testCrearMarcaNueva() {
+        Marca nueva = new Marca("Seat", "España");
+        when(marcaRepository.findByName("Seat")).thenReturn(Optional.empty());
+        when(marcaRepository.save(nueva)).thenReturn(nueva);
+
+        ResponseEntity<?> respuesta = marcaController.crearMarca(nueva);
+
+        assertEquals(HttpStatus.CREATED, respuesta.getStatusCode());
+        assertSame(nueva, respuesta.getBody());
+        verify(marcaRepository, times(1)).save(nueva);
+    }
+
+    @Test
+    void testCrearMarcaNombreDuplicado() {
+        Marca duplicada = new Marca("Toyota", "Japon");
+        when(marcaRepository.findByName("Toyota")).thenReturn(Optional.of(toyota));
+
+        ResponseEntity<?> respuesta = marcaController.crearMarca(duplicada);
+
+        assertEquals(HttpStatus.CONFLICT, respuesta.getStatusCode());
+        verify(marcaRepository, never()).save(any(Marca.class));
+    }
+
+    @Test
+    void testActualizarMarcaExistente() {
+        Marca cambios = new Marca("Toyota", "Japón actualizado");
+        when(marcaRepository.findById(1L)).thenReturn(Optional.of(toyota));
+        when(marcaRepository.save(toyota)).thenReturn(toyota);
+
+        ResponseEntity<?> respuesta = marcaController.actualizarMarca(1L, cambios);
+
+        assertEquals(HttpStatus.OK, respuesta.getStatusCode());
+        assertEquals("Japón actualizado", toyota.getCountry());
+        verify(marcaRepository, times(1)).save(toyota);
+    }
+
+    @Test
+    void testActualizarMarcaInexistente() {
+        Marca cambios = new Marca("Fake", "Pais");
+        when(marcaRepository.findById(99L)).thenReturn(Optional.empty());
+
+        ResponseEntity<?> respuesta = marcaController.actualizarMarca(99L, cambios);
+
+        assertEquals(HttpStatus.NOT_FOUND, respuesta.getStatusCode());
+        verify(marcaRepository, never()).save(any(Marca.class));
+    }
+
+    @Test
+    void testActualizarMarcaConNombreYaUsado() {
+        Marca cambios = new Marca("Ford", "Japon");
+        when(marcaRepository.findById(1L)).thenReturn(Optional.of(toyota));
+        when(marcaRepository.findByName("Ford")).thenReturn(Optional.of(ford));
+
+        ResponseEntity<?> respuesta = marcaController.actualizarMarca(1L, cambios);
+
+        assertEquals(HttpStatus.CONFLICT, respuesta.getStatusCode());
+        verify(marcaRepository, never()).save(any(Marca.class));
+    }
+
+    @Test
+    void testEliminarMarcaExistente() {
+        when(marcaRepository.findById(1L)).thenReturn(Optional.of(toyota));
+
+        ResponseEntity<Void> respuesta = marcaController.eliminarMarca(1L);
+
+        assertEquals(HttpStatus.NO_CONTENT, respuesta.getStatusCode());
+        verify(marcaRepository, times(1)).deleteById(1L);
+    }
+
+    @Test
+    void testEliminarMarcaInexistente() {
+        when(marcaRepository.findById(99L)).thenReturn(Optional.empty());
+
+        ResponseEntity<Void> respuesta = marcaController.eliminarMarca(99L);
+
+        assertEquals(HttpStatus.NOT_FOUND, respuesta.getStatusCode());
+        verify(marcaRepository, never()).deleteById(anyLong());
+    }
 }

--- a/FrontEnd/src/app/admin/marcas/page.tsx
+++ b/FrontEnd/src/app/admin/marcas/page.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import AdminShell from "@/components/admin/AdminShell";
+import SlideOver from "@/components/admin/SlideOver";
+
+interface Marca {
+  id: number;
+  name: string;
+  country: string;
+}
+
+interface Coche {
+  id: number;
+  marca: string;
+}
+
+interface MarcaForm {
+  name: string;
+  country: string;
+}
+
+const FORM_VACIO: MarcaForm = {
+  name: "",
+  country: "",
+};
+
+export default function AdminMarcasPage() {
+  const [marcas, setMarcas] = useState<Marca[]>([]);
+  const [coches, setCoches] = useState<Coche[]>([]);
+  const [busqueda, setBusqueda] = useState("");
+
+  const [drawerAbierto, setDrawerAbierto] = useState(false);
+  const [editando, setEditando] = useState<Marca | null>(null);
+  const [form, setForm] = useState<MarcaForm>(FORM_VACIO);
+  const [guardando, setGuardando] = useState(false);
+  const [errorForm, setErrorForm] = useState("");
+
+  const [confirmId, setConfirmId] = useState<number | null>(null);
+  const [borrando, setBorrando] = useState<number | null>(null);
+
+  const [aviso, setAviso] = useState<{ tipo: "ok" | "err"; texto: string } | null>(
+    null
+  );
+
+  const cargarDatos = () => {
+    fetch("http://localhost:8080/api/marcas")
+      .then((r) => (r.ok ? r.json() : []))
+      .then(setMarcas)
+      .catch(() => setMarcas([]));
+    fetch("http://localhost:8080/api/coches")
+      .then((r) => (r.ok ? r.json() : []))
+      .then(setCoches)
+      .catch(() => setCoches([]));
+  };
+
+  useEffect(cargarDatos, []);
+
+  useEffect(() => {
+    if (!aviso) return;
+    const t = setTimeout(() => setAviso(null), 3500);
+    return () => clearTimeout(t);
+  }, [aviso]);
+
+  const contarCoches = (nombreMarca: string) =>
+    coches.filter(
+      (c) => c.marca.toLowerCase() === nombreMarca.toLowerCase()
+    ).length;
+
+  const marcasFiltradas = useMemo(() => {
+    const lista = busqueda.trim()
+      ? marcas.filter((m) => {
+          const q = busqueda.trim().toLowerCase();
+          return (
+            m.name.toLowerCase().includes(q) ||
+            (m.country || "").toLowerCase().includes(q)
+          );
+        })
+      : marcas;
+    return [...lista].sort((a, b) => b.id - a.id);
+  }, [marcas, busqueda]);
+
+  const abrirNuevo = () => {
+    setEditando(null);
+    setForm(FORM_VACIO);
+    setErrorForm("");
+    setDrawerAbierto(true);
+  };
+
+  const abrirEditar = (m: Marca) => {
+    setEditando(m);
+    setForm({ name: m.name, country: m.country || "" });
+    setErrorForm("");
+    setDrawerAbierto(true);
+  };
+
+  const cerrarDrawer = () => {
+    if (guardando) return;
+    setDrawerAbierto(false);
+  };
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const guardar = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrorForm("");
+
+    if (!form.name.trim() || !form.country.trim()) {
+      setErrorForm("Nombre y país son obligatorios.");
+      return;
+    }
+
+    const token = localStorage.getItem("token");
+    if (!token) {
+      setErrorForm("Sesión expirada. Vuelve a iniciar sesión.");
+      return;
+    }
+
+    const payload = { name: form.name.trim(), country: form.country.trim() };
+
+    setGuardando(true);
+    try {
+      const url = editando
+        ? `http://localhost:8080/api/marcas/${editando.id}`
+        : "http://localhost:8080/api/marcas";
+      const res = await fetch(url, {
+        method: editando ? "PUT" : "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        if (res.status === 409) {
+          setErrorForm("Ya existe una marca con ese nombre.");
+        } else if (res.status === 403) {
+          setErrorForm("No tienes permisos para esta acción.");
+        } else if (res.status === 404) {
+          setErrorForm("La marca ya no existe.");
+        } else {
+          setErrorForm("No se pudo guardar. Inténtalo de nuevo.");
+        }
+        return;
+      }
+
+      setAviso({
+        tipo: "ok",
+        texto: editando ? "Marca actualizada." : "Marca añadida.",
+      });
+      setDrawerAbierto(false);
+      cargarDatos();
+    } catch {
+      setErrorForm("No se pudo conectar con el servidor.");
+    } finally {
+      setGuardando(false);
+    }
+  };
+
+  const borrar = async (id: number) => {
+    const token = localStorage.getItem("token");
+    if (!token) return;
+    setBorrando(id);
+    try {
+      const res = await fetch(`http://localhost:8080/api/marcas/${id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        setAviso({ tipo: "err", texto: "No se pudo eliminar la marca." });
+        return;
+      }
+      setAviso({ tipo: "ok", texto: "Marca eliminada." });
+      setConfirmId(null);
+      cargarDatos();
+    } catch {
+      setAviso({ tipo: "err", texto: "Sin conexión con el servidor." });
+    } finally {
+      setBorrando(null);
+    }
+  };
+
+  return (
+    <AdminShell>
+      <main className="max-w-[1380px] mx-auto px-6 lg:px-10 pt-12 lg:pt-16 pb-24">
+        <header className="border-b border-line pb-8 mb-10">
+          <div className="flex items-baseline justify-between mb-4">
+            <p className="kicker">§ 03 · Marcas</p>
+            <p className="kicker hidden md:block">
+              {marcasFiltradas.length.toString().padStart(2, "0")} de{" "}
+              {marcas.length.toString().padStart(2, "0")}
+            </p>
+          </div>
+          <div className="flex items-end justify-between gap-6 flex-wrap">
+            <h1 className="h-display text-5xl md:text-6xl lg:text-7xl">
+              Casas y
+              <br />
+              <em className="italic-rust">carrocerías.</em>
+            </h1>
+            <button onClick={abrirNuevo} className="btn-ink shrink-0">
+              + Nueva marca
+            </button>
+          </div>
+        </header>
+
+        {/* Búsqueda */}
+        <section className="mb-10 max-w-md">
+          <label htmlFor="busqueda-marcas" className="kicker block mb-1">
+            Buscar por nombre o país
+          </label>
+          <input
+            id="busqueda-marcas"
+            type="text"
+            value={busqueda}
+            onChange={(e) => setBusqueda(e.target.value)}
+            placeholder="ej. Toyota, Japón…"
+            className="field"
+          />
+        </section>
+
+        {/* Aviso transitorio */}
+        {aviso && (
+          <div
+            className={`mb-8 px-4 py-3 border-l-2 text-sm animate-fadeup ${
+              aviso.tipo === "ok"
+                ? "border-ink bg-bone-soft text-ink"
+                : "border-rust bg-bone-soft text-rust"
+            }`}
+          >
+            {aviso.texto}
+          </div>
+        )}
+
+        {/* Tabla */}
+        {marcasFiltradas.length === 0 ? (
+          <div className="py-32 text-center border-t border-b border-line">
+            <p className="h-mid italic-soft text-3xl md:text-4xl text-ink-muted">
+              Nada que mostrar
+            </p>
+            <p className="kicker mt-3">
+              {busqueda
+                ? "Prueba con otra búsqueda"
+                : "Empieza añadiendo una marca"}
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="adm-table">
+              <thead>
+                <tr>
+                  <th className="w-[60px]">#</th>
+                  <th>Nombre</th>
+                  <th>País</th>
+                  <th className="w-[140px]">Coches</th>
+                  <th className="w-[200px] text-right">Acciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                {marcasFiltradas.map((m) => {
+                  const esConfirmacion = confirmId === m.id;
+                  const nCoches = contarCoches(m.name);
+                  return (
+                    <tr key={m.id}>
+                      <td className="font-mono text-ink-muted">
+                        {m.id.toString().padStart(3, "0")}
+                      </td>
+                      <td>
+                        <p className="h-mid text-[1.2rem]">{m.name}</p>
+                      </td>
+                      <td className="text-ink-soft">{m.country || "—"}</td>
+                      <td>
+                        <span className="badge">
+                          {nCoches} coche{nCoches === 1 ? "" : "s"}
+                        </span>
+                      </td>
+                      <td className="text-right">
+                        {esConfirmacion ? (
+                          <span className="inline-flex items-center gap-4">
+                            <span className="kicker !text-rust">
+                              ¿Eliminar?
+                            </span>
+                            <button
+                              onClick={() => borrar(m.id)}
+                              disabled={borrando === m.id}
+                              className="row-action danger"
+                            >
+                              {borrando === m.id ? "…" : "Sí"}
+                            </button>
+                            <span className="text-ink-muted">·</span>
+                            <button
+                              onClick={() => setConfirmId(null)}
+                              className="row-action"
+                            >
+                              No
+                            </button>
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center gap-5">
+                            <button
+                              onClick={() => abrirEditar(m)}
+                              className="row-action"
+                            >
+                              Editar
+                            </button>
+                            <span className="text-line">·</span>
+                            <button
+                              onClick={() => setConfirmId(m.id)}
+                              className="row-action danger"
+                            >
+                              Eliminar
+                            </button>
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+
+      <SlideOver
+        open={drawerAbierto}
+        onClose={cerrarDrawer}
+        kicker={
+          editando
+            ? `§ Marca #${editando.id.toString().padStart(3, "0")}`
+            : "§ Nueva marca"
+        }
+        title={editando ? "Editar marca" : "Añadir marca"}
+      >
+        <form onSubmit={guardar} className="space-y-1">
+          <p className="text-bone/70 leading-relaxed mb-8">
+            {editando
+              ? "Modifica los datos de la marca. Afecta solo al catálogo de marcas."
+              : "Registra una marca nueva para poder asignarla a los coches."}
+          </p>
+
+          <div>
+            <label className="kicker !text-bone/60 block mb-1">Nombre</label>
+            <input
+              type="text"
+              name="name"
+              value={form.name}
+              onChange={onChange}
+              required
+              placeholder="Toyota, Ford, BMW…"
+              className="field-dark"
+            />
+          </div>
+
+          <div>
+            <label className="kicker !text-bone/60 block mb-1 mt-5">
+              País
+            </label>
+            <input
+              type="text"
+              name="country"
+              value={form.country}
+              onChange={onChange}
+              required
+              placeholder="Japón, EEUU, Alemania…"
+              className="field-dark"
+            />
+          </div>
+
+          {errorForm && (
+            <p
+              className="mt-6 text-rust text-sm border-l-2 border-rust pl-3"
+              role="alert"
+            >
+              {errorForm}
+            </p>
+          )}
+
+          <div className="flex flex-wrap gap-3 mt-10 pt-6 border-t border-bone/10">
+            <button
+              type="submit"
+              disabled={guardando}
+              className="btn-bone flex-1"
+            >
+              {guardando
+                ? "Guardando…"
+                : editando
+                ? "Guardar cambios"
+                : "Añadir marca"}
+            </button>
+            <button
+              type="button"
+              onClick={cerrarDrawer}
+              className="btn-bone-ghost"
+              disabled={guardando}
+            >
+              Cancelar
+            </button>
+          </div>
+        </form>
+      </SlideOver>
+    </AdminShell>
+  );
+}

--- a/FrontEnd/src/components/admin/AdminShell.tsx
+++ b/FrontEnd/src/components/admin/AdminShell.tsx
@@ -151,6 +151,12 @@ export default function AdminShell({ children }: AdminShellProps) {
               Inventario
             </Link>
             <Link
+              href="/admin/marcas"
+              className={`tab ${isActive("/admin/marcas") ? "is-active" : ""}`}
+            >
+              Marcas
+            </Link>
+            <Link
               href="/admin/usuarios"
               className={`tab ${
                 isActive("/admin/usuarios") ? "is-active" : ""
@@ -197,6 +203,14 @@ export default function AdminShell({ children }: AdminShellProps) {
             }`}
           >
             Inventario
+          </Link>
+          <Link
+            href="/admin/marcas"
+            className={`tab shrink-0 ${
+              isActive("/admin/marcas") ? "is-active" : ""
+            }`}
+          >
+            Marcas
           </Link>
           <Link
             href="/admin/usuarios"


### PR DESCRIPTION
## Resumen

Cierra el CRUD de marcas, que hasta ahora solo tenía endpoints de lectura.

### Backend
- `findByName` en `MarcaRepository` para detectar nombres duplicados.
- `POST /api/marcas`, `PUT /api/marcas/{id}`, `DELETE /api/marcas/{id}` en `MarcaController`, siguiendo el patrón de `CocheController`. Devuelve 409 si el nombre ya existe (en PUT solo si el nombre cambia).
- 7 tests nuevos en `MarcaControllerTest` (crear, duplicado, actualizar, inexistente, nombre ya usado, borrar, borrar inexistente). Suite completa: 78 tests en verde.

### Frontend
- Pantalla `/admin/marcas` con el mismo patrón que coches y usuarios: tabla con recuento de coches por marca, buscador, slide-over de crear/editar y borrado con confirmación inline.
- Pestaña "Marcas" añadida al nav del admin (escritorio y móvil).

El `Select` de marca del formulario de coche ya tiraba de `/api/marcas`, así que se actualiza solo.

## Pruebas
- `mvn test` → 78 tests, 0 fallos
- `npm run lint` y `npm run build` sin errores
- Smoke test manual de los 4 endpoints (201 / 409 / 200 / 204 / 404)

Closes #59